### PR TITLE
Fabric Installation Script

### DIFF
--- a/id_auth/Install-Fabric.ps1
+++ b/id_auth/Install-Fabric.ps1
@@ -1,0 +1,22 @@
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
+Import-Module -Name .\Fabric-Install-Utilities.psm1 -Verbose
+
+if(!(Test-Prerequisite '*.NET Core*Windows Server Hosting*' 1.1.30327.81))
+{
+    Write-Host "Windows Server Hosting Bundle minimum version 1.1.30327.81 not installed...installing version 1.1.30327.81"
+    Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=844461 -OutFile bundle.exe
+    Start-Process bundle.exe -Wait -ArgumentList '/quiet /install'
+    net stop was /y
+    net start w3svc
+}
+
+if(!(Test-Prerequisite '*CouchDB*'))
+{
+    Write-Host "CouchDB not installed, installing CouchDB Version 2.1.0.0"
+    Invoke-WebRequest -Uri https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi -OutFile apache-couchdb-2.1.0.msi
+    Start-Process apache-couchdb-2.1.0.msi -Wait
+}elseif (!(Test-Prerequisite '*CouchDB*' 2.0.0.1)) {
+    Write-Host "CouchDB is installed but does not meet the minimum version requirements, you must have CouchDB 2.0.0.1 or greater installed: https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi"
+    exit 1
+}
+  

--- a/id_auth/Install-Fabric.ps1
+++ b/id_auth/Install-Fabric.ps1
@@ -1,22 +1,66 @@
+param(
+    [String]$identityVersion,
+    [String]$webroot = "C:\inetpub\wwwroot", 
+	[String]$iisUser = "IIS_IUSRS", 
+	[String]$sslCertificateThumbprint,
+	[String]$couchDbServer,
+	[String]$couchDbUsername,
+	[String]$couchDbPassword,
+	[String]$appInsightsInstrumentationKey,
+	[String]$siteName = "Default Web Site",
+	[String]$hostUrl
+)
+
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
 Import-Module -Name .\Fabric-Install-Utilities.psm1 -Verbose
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+
 
 if(!(Test-Prerequisite '*.NET Core*Windows Server Hosting*' 1.1.30327.81))
 {
     Write-Host "Windows Server Hosting Bundle minimum version 1.1.30327.81 not installed...installing version 1.1.30327.81"
-    Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=844461 -OutFile bundle.exe
-    Start-Process bundle.exe -Wait -ArgumentList '/quiet /install'
+    Invoke-WebRequest -Uri https://go.microsoft.com/fwlink/?linkid=844461 -OutFile $env:Temp\bundle.exe
+    Start-Process $env:Temp\bundle.exe -Wait -ArgumentList '/quiet /install'
     net stop was /y
     net start w3svc
+    Remove-Item $env:Temp\bundle.exe
 }
 
 if(!(Test-Prerequisite '*CouchDB*'))
 {
     Write-Host "CouchDB not installed, installing CouchDB Version 2.1.0.0"
-    Invoke-WebRequest -Uri https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi -OutFile apache-couchdb-2.1.0.msi
-    Start-Process apache-couchdb-2.1.0.msi -Wait
+    Invoke-WebRequest -Uri https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi -OutFile $env:Temp\apache-couchdb-2.1.0.msi
+    Start-Process $env:Temp\apache-couchdb-2.1.0.msi -Wait
+    Remove-Item $env:Temp\apache-couchdb-2.1.0.msi
 }elseif (!(Test-Prerequisite '*CouchDB*' 2.0.0.1)) {
     Write-Host "CouchDB is installed but does not meet the minimum version requirements, you must have CouchDB 2.0.0.1 or greater installed: https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi"
     exit 1
 }
+
+$outFile = "$env:Temp\Fabric.Identity.$identityVersion.zip"
+$targetDirectory = "$env:Temp\Fabric.Identity.$identityVersion"
+Write-Host "Downloading Fabric.Identity.$identityVersion.zip to $outFile"
+if(Test-Path $targetDirectory){
+    Remove-Item $targetDirectory -Force -Recurse
+}
+Invoke-WebRequest -Uri https://github.com/HealthCatalyst/Fabric.Identity/releases/download/v$identityVersion/Fabric.Identity.$identityVersion.zip -OutFile $outFile
+[System.IO.Compression.ZipFile]::ExtractToDirectory($outFile, $targetDirectory)
+
+Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1 -OutFile $env:Temp\Install-Identity-Windows.ps1
+$args = @()
+$args += ("-zipPackage", "$targetDirectory\drop\Fabric.Identity.Api.zip")
+$args += ("-sslCertificateThumbprint", $sslCertificateThumbprint)
+$args += ("-couchDbServer", $couchDbServer)
+$args += ("-couchDbUsername", $couchDbUsername)
+$args += ("-couchDbPassword", $couchDbPassword)
+$args += ("-appInsightsInstrumentationKey", $appInsightsInstrumentationKey)
+$args += ("-hostUrl", $hostUrl)
+if($webroot){
+    $args += ("-webroot", $webroot)
+}
+if($iisUser){
+    $args += ("-iisUser", $iisUser)
+}
+Invoke-Expression "$env:Temp\Install-Identity-Windows.ps1 $args"
+
   

--- a/id_auth/Install-Fabric.ps1
+++ b/id_auth/Install-Fabric.ps1
@@ -53,14 +53,14 @@ function Get-CommonArguments()
     return $installArgs
 }
 
-function Get-AccessToken($authUrl, $cliendId, $scope, $secret)
+function Get-AccessToken($authUrl, $clientId, $scope, $secret)
 {
     $url = "$authUrl/connect/token"
     $body = @{
-        client_id = $clientId
+        client_id = "$clientId"
         grant_type = "client_credentials"
-        scope = $scope
-        client_secret = $secret
+        scope = "$scope"
+        client_secret = "$secret"
     }
     $accessTokenResponse = Invoke-RestMethod -Method Post -Uri $url -Body $body
     return $accessTokenResponse.access_token
@@ -69,22 +69,22 @@ function Get-AccessToken($authUrl, $cliendId, $scope, $secret)
 function Create-ApiRegistration($authUrl, $body, $accessToken)
 {
     $url = "$authUrl/api/apiresource"
-    $headers = @{ "Accept" = "application/json"}
+    $headers = @{"Accept" = "application/json"}
     if($accessToken){
         $headers.Add("Authorization", "Bearer $accessToken")
     }
-    $registrationResponse = Invoke-RestMethod -Method Post -Uri $url -Body $body -ContentType "application/json"
+    $registrationResponse = Invoke-RestMethod -Method Post -Uri $url -Body $body -ContentType "application/json" -Headers $headers
     return $registrationResponse.apiSecret    
 }
 
 function Create-ClientRegistration($authUrl, $body, $accessToken)
 {
     $url = "$authUrl/api/client"
-    $headers = @{ "Accept" = "application/json"}
+    $headers = @{"Accept" = "application/json"}
     if($accessToken){
         $headers.Add("Authorization", "Bearer $accessToken")
     }
-    $registrationResponse = Invoke-RestMethod -Method Post -Uri $url -Body $body -ContentType "application/json"
+    $registrationResponse = Invoke-RestMethod -Method Post -Uri $url -Body $body -ContentType "application/json" -Headers $headers
     return $registrationResponse.clientSecret
 }
 
@@ -152,7 +152,7 @@ $body = @'
 '@
 $installerClientSecret = Create-ClientRegistration -authUrl $identityServerUrl -body $body
 
-$accessToken = Get-AccessToken -authUrl $identityServerUrl -cliendId "fabric-installer" -scope "fabric/identity.manageresources" -secret $installerClientSecret
+$accessToken = Get-AccessToken -authUrl $identityServerUrl -clientId "fabric-installer" -scope "fabric/identity.manageresources" -secret $installerClientSecret
 
 #Register authorization api
 $body = @'

--- a/id_auth/Install-Fabric.ps1
+++ b/id_auth/Install-Fabric.ps1
@@ -1,5 +1,6 @@
 param(
     [String]$identityVersion,
+    [String]$authorizationVersion,
     [String]$webroot = "C:\inetpub\wwwroot", 
 	[String]$iisUser = "IIS_IUSRS", 
 	[String]$sslCertificateThumbprint,
@@ -10,11 +11,47 @@ param(
 	[String]$siteName = "Default Web Site",
 	[String]$hostUrl
 )
-
+#default auth and identity versions to latest
 Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/InstallScripts/master/common/Fabric-Install-Utilities.psm1 -OutFile Fabric-Install-Utilities.psm1
 Import-Module -Name .\Fabric-Install-Utilities.psm1 -Verbose
 Add-Type -AssemblyName System.IO.Compression.FileSystem
+$workingDirectory = Split-Path $script:MyInvocation.MyCommand.Path
 
+function Get-FabricRelease($appName, $appVersion)
+{
+    $outFile = "$env:Temp\Fabric.$appName.$appVersion.zip"
+    $targetDirectory = "$env:Temp\Fabric.$appName.$appVersion"
+    Write-Host "Downloading Fabric.$appName.$appVersion.zip to $outFile"
+    if(Test-Path $targetDirectory){
+        Remove-Item $targetDirectory -Force -Recurse
+    }
+    Invoke-WebRequest -Uri https://github.com/HealthCatalyst/Fabric.$appName/releases/download/v$appVersion/Fabric.$appName.$appVersion.zip -OutFile $outFile
+    [System.IO.Compression.ZipFile]::ExtractToDirectory($outFile, $targetDirectory)
+    return "$targetDirectory\drop\Fabric.$appName.API.zip"
+}
+
+function Install-FabricRelease($appName, $installArgs)
+{
+    Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.$appName/master/Fabric.$appName.API/scripts/Install-$appName-Windows.ps1 -OutFile "$env:Temp\Install-$appName-Windows.ps1"
+    Invoke-Expression "$env:Temp\Install-$appName-Windows.ps1 $installArgs"
+}
+
+function Get-CommonArguments()
+{
+    $installArgs = @()
+    $installArgs += ("-sslCertificateThumbprint", $sslCertificateThumbprint)
+    $installArgs += ("-couchDbServer", $couchDbServer)
+    $installArgs += ("-couchDbUsername", $couchDbUsername)
+    $installArgs += ("-couchDbPassword", $couchDbPassword)
+    $installArgs += ("-appInsightsInstrumentationKey", $appInsightsInstrumentationKey)
+    if($webroot){
+        $installArgs += ("-webroot", $webroot)
+    }
+    if($iisUser){
+        $installArgs += ("-iisUser", $iisUser)
+    }
+    return $installArgs
+}
 
 if(!(Test-Prerequisite '*.NET Core*Windows Server Hosting*' 1.1.30327.81))
 {
@@ -28,39 +65,33 @@ if(!(Test-Prerequisite '*.NET Core*Windows Server Hosting*' 1.1.30327.81))
 
 if(!(Test-Prerequisite '*CouchDB*'))
 {
+    #add check to see if couchdb url is reachable
     Write-Host "CouchDB not installed, installing CouchDB Version 2.1.0.0"
     Invoke-WebRequest -Uri https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi -OutFile $env:Temp\apache-couchdb-2.1.0.msi
     Start-Process $env:Temp\apache-couchdb-2.1.0.msi -Wait
     Remove-Item $env:Temp\apache-couchdb-2.1.0.msi
+    #add ability to create admin user
 }elseif (!(Test-Prerequisite '*CouchDB*' 2.0.0.1)) {
     Write-Host "CouchDB is installed but does not meet the minimum version requirements, you must have CouchDB 2.0.0.1 or greater installed: https://dl.bintray.com/apache/couchdb/win/2.1.0/apache-couchdb-2.1.0.msi"
     exit 1
 }
 
-$outFile = "$env:Temp\Fabric.Identity.$identityVersion.zip"
-$targetDirectory = "$env:Temp\Fabric.Identity.$identityVersion"
-Write-Host "Downloading Fabric.Identity.$identityVersion.zip to $outFile"
-if(Test-Path $targetDirectory){
-    Remove-Item $targetDirectory -Force -Recurse
-}
-Invoke-WebRequest -Uri https://github.com/HealthCatalyst/Fabric.Identity/releases/download/v$identityVersion/Fabric.Identity.$identityVersion.zip -OutFile $outFile
-[System.IO.Compression.ZipFile]::ExtractToDirectory($outFile, $targetDirectory)
+$identityZipPackage = Get-FabricRelease Identity $identityVersion
+$identityArgs = Get-CommonArguments
+$identityArgs += ("-zipPackage", $identityZipPackage)
+$identityArgs += ("-hostUrl", $hostUrl)
+Install-FabricRelease Identity $identityArgs
 
-Invoke-WebRequest -Uri https://raw.githubusercontent.com/HealthCatalyst/Fabric.Identity/master/Fabric.Identity.API/scripts/Install-Identity-Windows.ps1 -OutFile $env:Temp\Install-Identity-Windows.ps1
-$args = @()
-$args += ("-zipPackage", "$targetDirectory\drop\Fabric.Identity.Api.zip")
-$args += ("-sslCertificateThumbprint", $sslCertificateThumbprint)
-$args += ("-couchDbServer", $couchDbServer)
-$args += ("-couchDbUsername", $couchDbUsername)
-$args += ("-couchDbPassword", $couchDbPassword)
-$args += ("-appInsightsInstrumentationKey", $appInsightsInstrumentationKey)
-$args += ("-hostUrl", $hostUrl)
-if($webroot){
-    $args += ("-webroot", $webroot)
-}
-if($iisUser){
-    $args += ("-iisUser", $iisUser)
-}
-Invoke-Expression "$env:Temp\Install-Identity-Windows.ps1 $args"
+cd $workingDirectory
+
+$authorizationZipPackage = Get-FabricRelease Authorization $authorizationVersion
+$authorizationArgs = Get-CommonArguments
+$authorizationArgs += ("-zipPackage", $authorizationZipPackage)
+$authorizationArgs += ("-identityServerUrl", "$hostUrl/identity")
+Install-FabricRelease Authorization $authorizationArgs
+
+cd $workingDirectory
+
+
 
   


### PR DESCRIPTION
The script in its current state will:

1. Check for and install (if needed) the Windows Server Hosting components for dotnet core
2. Check for and install (if needed) CouchDb on the local server
3. Install and configure Fabric.Identity
4. Install and configure Fabric.Authorization
5. Register the installer, registration api, authorization api and group fetcher

Enhancements that are coming planned are:
1. The ability to default the Identity and Authorization versions to the latest available
2. An enhanced check to see if CouchDb is reachable based on an input CouchDb URI
3. Creation of the admin user for CouchDb
4. Making the script work for an upgrade as well as an install