### PR TITLE
Aclreorder

### DIFF
--- a/common/Fabric-Install-Utilities.psm1
+++ b/common/Fabric-Install-Utilities.psm1
@@ -54,21 +54,21 @@ function New-AppRoot($appDirectory, $iisUser){
         $readAccessRule = New-Object System.Security.AccessControl.FileSystemAccessRule($iisUser, "Read", "ContainerInherit,ObjectInherit", "None", "Allow")
 
         try {			
-			$acl.AddAccessRule($writeAccessRule)
+            $acl.AddAccessRule($writeAccessRule)
         } catch [System.InvalidOperationException]
         {
             # Attempt to fix parent identity directory before log directory
             RepairAclCanonicalOrder(Get-Acl $appDirectory)
             RepairAclCanonicalOrder($acl)
-			$acl.AddAccessRule($writeAccessRule)
+            $acl.AddAccessRule($writeAccessRule)
         }
 		
         try {
-			$acl.AddAccessRule($readAccessRule)
+            $acl.AddAccessRule($readAccessRule)
         } catch [System.InvalidOperationException]
         {
             RepairAclCanonicalOrder($acl)
-			$acl.AddAccessRule($readAccessRule)
+            $acl.AddAccessRule($readAccessRule)
         }
 		
 		try {


### PR DESCRIPTION
Script to reorder acls without resetting permissions via icacls reset

Being extra safe with try catches around adding rules since in original state saw that trying to add a rule would raise an error as well.