### PR TITLE
Update Test-DiscoveryHasBuildVerison to use Invoke-RestMethod

### DIFF
--- a/common/Fabric-Install-Utilities.psm1
+++ b/common/Fabric-Install-Utilities.psm1
@@ -586,7 +586,7 @@ function Write-Console($message){
 }
 
 function Test-DiscoveryHasBuildVersion($discoveryUrl, $credential) {
-    $response = [xml](Invoke-WebRequest -Method Get -Uri "$discoveryUrl/`$metadata" -Credential $credential -ContentType "application/xml")
+    $response = [xml](Invoke-RestMethod -Method Get -Uri "$discoveryUrl/`$metadata" -Credential $credential -ContentType "application/xml")
 	
     return $response.Edmx.DataServices.Schema.EntityType.Property.Name -contains 'BuildNumber'
 }


### PR DESCRIPTION
Change Invoke-WebRequest to Invoke-RestMethod to prevent issues when IE Engine is not available